### PR TITLE
fix: 修复 PDF 文字显示异常及类型错误

### DIFF
--- a/src/components/ProfilePdfDocument.tsx
+++ b/src/components/ProfilePdfDocument.tsx
@@ -4,7 +4,20 @@ import type { AIAnalysis, GitHubData } from '@/types/github'
 // 注册字体以支持中文
 Font.register({
 	family: 'NotoSansSC',
-	src: 'https://cdn.jsdelivr.net/npm/@fontsource/noto-sans-sc@5.0.12/files/noto-sans-sc-chinese-simplified-400-normal.woff',
+	fonts: [
+		{
+			src: 'https://cdn.jsdelivr.net/npm/@fontsource/noto-sans-sc@5.0.12/files/noto-sans-sc-chinese-simplified-400-normal.woff',
+			fontWeight: 400,
+		},
+		{
+			src: 'https://cdn.jsdelivr.net/npm/@fontsource/noto-sans-sc@5.0.12/files/noto-sans-sc-chinese-simplified-500-normal.woff',
+			fontWeight: 500,
+		},
+		{
+			src: 'https://cdn.jsdelivr.net/npm/@fontsource/noto-sans-sc@5.0.12/files/noto-sans-sc-chinese-simplified-700-normal.woff',
+			fontWeight: 700,
+		},
+	],
 })
 
 // 为了更好的中文支持，实际项目中通常需要引入中文字体文件
@@ -276,9 +289,9 @@ const ProfilePdfDocument = ({ data, analysis }: ProfilePdfProps) => {
 										: 'No description'}
 								</Text>
 								<View style={styles.repoMeta}>
-									<Text style={{ marginRight: 10 }}>⭐ {repo.stargazerCount}</Text>
+									<Text style={{ marginRight: 10 }}>⭐ {repo.stars}</Text>
 									<Text style={{ flexDirection: 'row', alignItems: 'center' }}>
-										<Text style={{ fontSize: 8 }}>●</Text> {repo.primaryLanguage?.name}
+										<Text style={{ fontSize: 8 }}>●</Text> {repo.language}
 									</Text>
 								</View>
 							</View>


### PR DESCRIPTION
## 摘要
解决 #1。

本 PR 修复了 PDF 文件中文字显示乱码的问题，并修正了 PDF 生成组件中的部分类型错误。

## 变更详情
- **字体注册**: 为 `NotoSansSC` 注册了多个字重（400, 500, 700）。之前仅注册了 400，导致使用粗体或中等字重的文本（如标题）因缺少字形而显示异常（乱码）。
- **类型修复**: 修正了 `src/components/ProfilePdfDocument.tsx` 中使用的 `Repository` 接口属性名错误：
  - `repo.stargazerCount` -> `repo.stars`
  - `repo.primaryLanguage?.name` -> `repo.language`

## 验证
- 验证 `npm run build` 构建成功。
- 检查确认所有注册的字体 URL 均可访问。