### PR TITLE
feat: expand language color mapping

### DIFF
--- a/supabase/functions/github-data/index.ts
+++ b/supabase/functions/github-data/index.ts
@@ -527,27 +527,90 @@ serve(async (req) => {
 	}
 })
 
-// Language color mapping
+// Language color mapping - based on GitHub Linguist colors
 function getLanguageColor(language: string): string {
 	const colors: Record<string, string> = {
+		// Web & Script
 		TypeScript: '#3178c6',
 		JavaScript: '#f1e05a',
 		Python: '#3572A5',
+		HTML: '#e34c26',
+		CSS: '#563d7c',
+		SCSS: '#c6538c',
+		Sass: '#a53b70',
+		Less: '#1d365d',
+		Vue: '#41b883',
+		React: '#61dafb',
+
+		// Systems & Compiled
 		Java: '#b07219',
 		'C++': '#f34b7d',
 		C: '#555555',
+		'C#': '#178600',
 		Go: '#00ADD8',
 		Rust: '#dea584',
 		Ruby: '#701516',
 		PHP: '#4F5D95',
 		Swift: '#F05138',
 		Kotlin: '#A97BFF',
+		Scala: '#c22d40',
+		Elixir: '#6e4a7e',
+		Erlang: '#b83998',
+		Haskell: '#5e5086',
+		Julia: '#9558b2',
+		Lua: '#000080',
+		ObjectiveC: '#438eff',
+		Perl: '#0298c3',
+		R: '#198ce7',
+
+		// Mobile
 		Dart: '#00B4AB',
-		Vue: '#41b883',
-		HTML: '#e34c26',
-		CSS: '#563d7c',
+		Flutter: '#02569b',
+
+		// Data & Config
+		SQL: '#e38c00',
+		YAML: '#cb171e',
+		JSON: '#292929',
+		XML: '#0060ac',
+		Markdown: '#083fa1',
+		GraphQL: '#e535ab',
+
+		// Shell & DevOps
 		Shell: '#89e051',
 		Dockerfile: '#384d54',
+		Makefile: '#6d8086',
+		CMake: '#064f8c',
+		Ansible: '#41b883',
+		Terraform: '#7f42ae',
+
+		// Other
+		Zig: '#f7a41d',
+		Nim: '#ffc200',
+		V: '#5d87bd',
+		Elm: '#60b5cc',
+		Reason: '#da584b',
+		PureScript: '#1D222D',
+		Clarity: '#5546ff',
+		Solidity: '#aa6746',
+		Move: '#4d4d4d',
+
+		// Legacy & Misc
+		Assembly: '#6e4c13',
+		Fortran: '#4d41b1',
+		Ada: '#02f88c',
+		COBOL: '#00d1c1',
+		Lisp: '#3fb68b',
+		Clojure: '#91dc47',
+		Racket: '#3c5caa',
+		Scheme: '#1e4aec',
+		'APL': '#5a616a',
+		'F#': '#378bba',
+		Forth: '#341708',
+		Io: '#a8b9c0',
+		Tcl: '#e4cc96',
+		AutoHotkey: '#6594b9',
+		Nix: '#7e7eff',
+		Protocol Buffer: '#e6e7e8',
 	}
 	return colors[language] || '#8b949e'
 }


### PR DESCRIPTION
### **User description**
## 功能改进

扩展  函数，添加 50+ 编程语言的颜色映射。

### 新增语言分类

**Web & Script:**
- React, SCSS, Sass, Less

**Systems & Compiled:**
- C#, Scala, Elixir, Erlang, Haskell, Julia, Lua, Objective-C, Perl, R

**Mobile:**
- Flutter

**Data & Config:**
- SQL, YAML, JSON, XML, Markdown, GraphQL

**Shell & DevOps:**
- Makefile, CMake, Ansible, Terraform

**Other:**
- Zig, Nim, V, Elm, Reason, PureScript, Clarity, Solidity, Move

**Legacy & Misc:**
- Assembly, Fortran, Ada, COBOL, Lisp, Clojure, Racket, Scheme, APL, F#, Forth, Io, Tcl, AutoHotkey, Nix, Protocol Buffer

### 解决的问题

- 修复 Issue #8: 小众语言显示灰色默认颜色
- 提升视觉效果，代码星系更加丰富多彩

---

**相关 Issue:** #8


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add rate limiting for REST API requests to prevent GitHub API throttling
  - Implement 1.5s delay between requests (~40 requests/hour)
  - Process language fetches sequentially instead of parallel

- Expand language color mapping with 50+ programming languages
  - Organize colors by category: Web, Systems, Mobile, Data, DevOps, Legacy
  - Replace gray default with vibrant GitHub Linguist-based colors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["REST API Requests"] -->|"Add Rate Limiting"| B["1.5s Delay Between Calls"]
  B -->|"Sequential Processing"| C["Avoid GitHub Throttling"]
  D["Language Color Mapping"] -->|"Expand from 15 to 65+ Languages"| E["Organized by Category"]
  E -->|"GitHub Linguist Colors"| F["Enhanced Visual Display"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement, bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Rate limiting and expanded language color support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

supabase/functions/github-data/index.ts

<ul><li>Add rate limiting mechanism with 1.5s delay between REST API requests <br>to prevent GitHub API throttling<br> <li> Convert parallel language fetching to sequential processing with <br>delays for each repository<br> <li> Expand language color mapping from ~15 to 65+ languages organized by <br>category (Web, Systems, Mobile, Data, DevOps, Legacy)<br> <li> Update comments to clarify rate limiting strategy and GitHub Linguist <br>color source</ul>


</details>


  </td>
  <td><a href="https://github.com/qqyule/gitfolio-x/pull/12/files#diff-2be4e514645b0fa91091c099432cd9172da6838a44340e6782b3f70201a5f894">+118/-23</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

